### PR TITLE
Event-driven RoCEv2 PRBS dispatch (continuous, no software poke)

### DIFF
--- a/firmware/python/rocev2_10gbe_rudp_kcu105_example/_RoCEv2AxiStreamRdma.py
+++ b/firmware/python/rocev2_10gbe_rudp_kcu105_example/_RoCEv2AxiStreamRdma.py
@@ -16,14 +16,17 @@ class RoCEv2AxiStreamRdma(pr.Device):
                   **kwargs):
         super().__init__(**kwargs)
 
-        self.add(pr.RemoteCommand(
-            name        = 'StartDispatching',
-            description = 'Rising-edge launch of the dispatch burst. toggle (1->0) re-arms the FW SynchronizerEdge',
-            offset      = 0x00,
-            bitSize     = 1,
-            bitOffset   = 0,
-            base        = pr.UInt,
-            function    = pr.RemoteCommand.toggle,
+        self.add(pr.RemoteVariable(
+            name         = 'DispatchEnable',
+            description  = 'Arm continuous event-driven dispatch: while set, the FW issues '
+                           'one RDMA WRITE-with-immediate per complete PRBS packet buffered '
+                           'in the repack FIFO. Set with SsiPrbsTx.TxEn=True for a '
+                           'self-sustaining stream; clear to stop',
+            offset       = 0x00,
+            bitSize      = 1,
+            bitOffset    = 0,
+            base         = pr.Bool,
+            mode         = 'RW',
         ))
 
         self.add(pr.RemoteVariable(
@@ -82,15 +85,6 @@ class RoCEv2AxiStreamRdma(pr.Device):
             description  = 'Number of RemAddr increments before wrapping back to base',
             offset       = 0x20,
             bitSize      = 32,
-            mode         = 'RW',
-        ))
-
-        self.add(pr.RemoteVariable(
-            name         = 'DispatchCounter',
-            description  = 'Number of dispatch bursts to issue',
-            offset       = 0x24,
-            bitSize      = dispatchBits,
-            disp         = '{:d}',
             mode         = 'RW',
         ))
 

--- a/firmware/python/rocev2_10gbe_rudp_kcu105_example/_Root.py
+++ b/firmware/python/rocev2_10gbe_rudp_kcu105_example/_Root.py
@@ -24,8 +24,7 @@ import rogue.utilities.fileio
 import simple_10gbe_rudp_kcu105_example as baseBoard
 import rocev2_10gbe_rudp_kcu105_example as roceBoard
 
-# TODO: Uncomment this after the rogue v6.14.0 tag release
-#rogue.Version.minVersion('6.14.0')
+rogue.Version.minVersion('6.14.0')
 
 # IBV_MTU enum values — mirrors libibverbs ibv_mtu
 IBV_MTU_256  = 1
@@ -246,8 +245,21 @@ class Root(pr.Root):
 
     def stop(self) -> None:
         """Tear down FPGA QP before transport is stopped."""
-        if self.useRoce and hasattr(self, 'rdmaRx') and hasattr(self.rdmaRx, 'teardownFpgaQp'):
-            self.rdmaRx.teardownFpgaQp()
+        if self.useRoce and hasattr(self, 'rdmaRx'):
+            # Disarm the PRBS source + RDMA dispatcher BEFORE tearing down the QP.
+            # Otherwise the FPGA is left free-running RDMA WRITEs at a destroyed QP,
+            # flooding the link and wedging the App datapath until an FPGA reload —
+            # the 0xF50 softRst only resets the Core transport, not the App. This
+            # leaked TxEn/DispatchEnable is what makes a software reconnect fail
+            # (rxCount stays 0) after the GUI/stream path leaves the source armed.
+            try:
+                self.App.SsiPrbsTx.TxEn.set(False)
+                self.App.RoCEv2AxiStreamRdma.DispatchEnable.set(False)
+                time.sleep(0.1)  # let the in-flight WRITE drain before QP teardown
+            except AttributeError:
+                pass
+            if hasattr(self.rdmaRx, 'teardownFpgaQp'):
+                self.rdmaRx.teardownFpgaQp()
         super().stop()
 
     @staticmethod

--- a/firmware/shared/rtl/RoCEv2AxiStreamRdma.vhd
+++ b/firmware/shared/rtl/RoCEv2AxiStreamRdma.vhd
@@ -8,7 +8,8 @@
 --     * REPACK      : drain an inbound AXI-Stream (PRBS) payload into the surf
 --                     290-bit RoceDmaReadResp record, one tLast-packet per
 --                     DMA-read request.
---     * DISPATCH    : issue RDMA-WRITE-with-immediate work requests.
+--     * DISPATCH    : event-driven — issue one RDMA-WRITE-with-immediate work
+--                     request per complete buffered packet while DispatchEnable=1.
 --     * COMPLETION  : count success/unsuccess work completions.
 --     * REG FILE    : ONE merged AXI-Lite slave exposing the union register map.
 -------------------------------------------------------------------------------
@@ -90,8 +91,8 @@ architecture rtl of RoCEv2AxiStreamRdma is
    type CompStateType is (ST0_IDLE, ST1_RECEIVED);
 
    type RegType is record
-      -- Dispatch control (from old WorkReqDispatcher AxilRegType)
-      startDispatching : sl;
+      -- Dispatch control
+      dispatchEnable   : sl;
       len              : slv(31 downto 0);
       rKey             : slv(31 downto 0);
       lKey             : slv(31 downto 0);
@@ -99,7 +100,6 @@ architecture rtl of RoCEv2AxiStreamRdma is
       dQpn             : slv(24 downto 0);
       rAddr            : slv(63 downto 0);
       addrWrapCount    : slv(31 downto 0);
-      dispatchCounter  : slv(DISPATCH_COUNTER_BITS_G-1 downto 0);
       -- Completion control / status (from old WorkCompChecker)
       resetCounters    : sl;
       successCounter   : slv(DISPATCH_COUNTER_BITS_G-1 downto 0);
@@ -114,7 +114,7 @@ architecture rtl of RoCEv2AxiStreamRdma is
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      startDispatching => '0',
+      dispatchEnable   => '0',
       len              => (others => '0'),
       rKey             => (others => '0'),
       lKey             => (others => '0'),
@@ -122,7 +122,6 @@ architecture rtl of RoCEv2AxiStreamRdma is
       dQpn             => (others => '0'),
       rAddr            => (others => '0'),
       addrWrapCount    => (others => '0'),
-      dispatchCounter  => (others => '0'),
       resetCounters    => '0',
       successCounter   => (others => '0'),
       unsuccessCounter => (others => '0'),
@@ -183,22 +182,26 @@ architecture rtl of RoCEv2AxiStreamRdma is
 
    type DispRegType is record
       state     : DispStateType;
-      count     : slv(DISPATCH_COUNTER_BITS_G-1 downto 0);
+      idCnt     : slv(DISPATCH_COUNTER_BITS_G-1 downto 0);
       addrCount : slv(DISPATCH_COUNTER_BITS_G-1 downto 0);
+      pktsAvail : unsigned(FIFO_ADDR_WIDTH_G downto 0);
       txMaster  : RoceWorkReqMasterType;
    end record DispRegType;
 
    constant DISP_INIT_C : DispRegType := (
       state     => ST0_IDLE,
-      count     => (others => '0'),
+      idCnt     => (others => '0'),
       addrCount => (others => '0'),
+      pktsAvail => (others => '0'),
       txMaster  => ROCE_WORK_REQ_MASTER_INIT_C);
 
    signal dispR   : DispRegType := DISP_INIT_C;
    signal dispRin : DispRegType;
 
-   -- StartDispatching rising-edge one-shot (surf.SynchronizerEdge output).
-   signal startDispatching : sl;
+   -- Internal FIFO slave (backpressure to the PRBS source). Exposed on the
+   -- sAxisSlave port AND read by the dispatch FSM to detect packet boundaries
+   -- (the tLast handshake increments pktsAvail).
+   signal sAxisSlaveInt : AxiStreamSlaveType;
 
    -- Track previous rAddr to detect a new MR (startZmq restart). Initialised to
    -- all-ones so the very first rAddr write always triggers an addrCount reset.
@@ -221,12 +224,15 @@ begin  -- architecture rtl
       port map (
          sAxisClk    => roceClk,
          sAxisRst    => roceRst,
-         sAxisMaster => sAxisMaster,   -- external inbound PRBS port
-         sAxisSlave  => sAxisSlave,    -- external backpressure to PRBS
+         sAxisMaster => sAxisMaster,    -- external inbound PRBS port
+         sAxisSlave  => sAxisSlaveInt,  -- backpressure to PRBS (also read by dispatch FSM)
          mAxisClk    => roceClk,
          mAxisRst    => roceRst,
          mAxisMaster => fifoMaster,    -- internal drain master
          mAxisSlave  => fifoSlave);    -- internal drain slave (REPACK FSM drives tReady)
+
+   -- Drive the external backpressure port from the internal FIFO slave signal.
+   sAxisSlave <= sAxisSlaveInt;
 
    ----------------------------------------------------------------------------
    -- Single merged AXI-Lite register file (Block E).
@@ -235,7 +241,7 @@ begin  -- architecture rtl
    -- offsets must match these exactly):
    --
    --   Offset  Bits    Access  Name              Field
-   --   0x00    [0]     RW      StartDispatching  startDispatching (edge-detected)
+   --   0x00    [0]     RW      DispatchEnable    dispatchEnable (level; arms auto-dispatch)
    --   0x04    [31:0]  RW      Len               len
    --   0x08    [31:0]  RW      RKey              rKey
    --   0x0C    [31:0]  RW      LKey              lKey
@@ -243,7 +249,6 @@ begin  -- architecture rtl
    --   0x14    [24:0]  RW      DQpn              dQpn   (UD field; unused by RC WRITE)
    --   0x18    [63:0]  RW      RemAddr           rAddr  (occupies 0x18/0x1C)
    --   0x20    [31:0]  RW      AddrWrapCount     addrWrapCount
-   --   0x24    [N:0]   RW      DispatchCounter   dispatchCounter
    --   0x100   [N:0]   RO      SuccessCounter    successCounter
    --   0x104   [N:0]   RO      UnsuccessCounter  unsuccessCounter
    --   0x108   [0]     RW      ResetCounters     resetCounters
@@ -262,7 +267,7 @@ begin  -- architecture rtl
       axiSlaveWaitTxn(regCon, axilWriteMaster, axilReadMaster, v.axilWriteSlave, v.axilReadSlave);
 
       -- RW dispatch block
-      axiSlaveRegister (regCon, x"000", 0, v.startDispatching);
+      axiSlaveRegister (regCon, x"000", 0, v.dispatchEnable);
       axiSlaveRegister (regCon, x"004", 0, v.len);
       axiSlaveRegister (regCon, x"008", 0, v.rKey);
       axiSlaveRegister (regCon, x"00C", 0, v.lKey);
@@ -272,7 +277,6 @@ begin  -- architecture rtl
       axiSlaveRegister (regCon, x"014", 0, v.dQpn);
       axiSlaveRegister (regCon, x"018", 0, v.rAddr);  -- 64-bit: occupies 0x18/0x1C
       axiSlaveRegister (regCon, x"020", 0, v.addrWrapCount);
-      axiSlaveRegister (regCon, x"024", 0, v.dispatchCounter);
 
       -- RO status block (based at 0x100, disjoint from the RW block)
       axiSlaveRegisterR(regCon, x"100", 0, r.successCounter);
@@ -482,31 +486,28 @@ begin  -- architecture rtl
    end process repSeq;
 
    ----------------------------------------------------------------------------
-   -- Block C: dispatch FSM + work-request issue.
+   -- Block C: event-driven dispatch FSM + work-request issue.
    --
-   -- StartDispatching (0x00) is a level register; the dispatch FSM triggers on
-   -- its RISING EDGE via surf.SynchronizerEdge (single roceClk domain). On the
-   -- edge the FSM issues exactly DispatchCounter (0x24) RDMA-WRITE-with-immediate
-   -- work requests, one per accepted workReqSlave handshake, reading the dispatch
-   -- fields from the register file.
+   -- DispatchEnable (0x00) is a level register that ARMS continuous dispatch.
+   -- While it is asserted, the FSM issues exactly one RDMA-WRITE-with-immediate
+   -- work request per COMPLETE PRBS packet buffered in the repack FIFO: pktsAvail
+   -- counts packets that have fully entered the FIFO (the sAxis tLast handshake)
+   -- minus those already claimed by an issued work request. Gating issuance on a
+   -- buffered packet guarantees the engine's subsequent DMA-read finds a full
+   -- packet, so the REPACK FSM never stalls mid-packet. There is NO software
+   -- trigger and NO burst count: a free-running PRBS source (TxEn=1) drives a
+   -- continuous, self-sustaining work-request stream.
    --
    -- dQpn is driven from register 0x14 (DQpn). It is a UD-datagram field; the
    -- RC RDMA-WRITE path routes via sQpn + the connection QP context, so dQpn is
    -- normally left 0 and does not affect the WRITE.
    ----------------------------------------------------------------------------
-   U_StartEdge : entity surf.SynchronizerEdge
-      generic map (
-         TPD_G         => TPD_G,
-         BYPASS_SYNC_G => true)         -- single roceClk domain, no CDC
-      port map (
-         clk        => roceClk,
-         dataIn     => r.startDispatching,
-         risingEdge => startDispatching);
-
-   dispComb : process (dispR, prevRAddr, r, startDispatching, workReqSlave) is
+   dispComb : process (dispR, prevRAddr, r, sAxisMaster, sAxisSlaveInt, workReqSlave) is
       variable v         : DispRegType;
       variable idPadding : slv(63 downto DISPATCH_COUNTER_BITS_G) := (others => '0');
       variable nextAddr  : unsigned(DISPATCH_COUNTER_BITS_G-1 downto 0);
+      variable pktEnter  : sl;
+      variable pktClaim  : sl;
    begin
       -- Latch current state
       v := dispR;
@@ -516,25 +517,32 @@ begin  -- architecture rtl
          v.txMaster.valid := '0';
       end if;
 
+      -- A complete PRBS packet finishes entering the repack FIFO when a tLast
+      -- beat is accepted on the FIFO slave handshake.
+      pktEnter := sAxisMaster.tValid and sAxisSlaveInt.tReady and sAxisMaster.tLast;
+      pktClaim := '0';
+
       case dispR.state is
 
          ---------------------------------------------------------------------
          when ST0_IDLE =>
             -- Reset addrCount when rAddr changes (new MR after startZmq restart);
-            -- addrCount persists across bursts within a session.
+            -- addrCount persists across the session.
             if r.rAddr /= prevRAddr then
                v.addrCount := (others => '0');
             end if;
-            -- The StartDispatching rising-edge one-shot launches the burst.
-            if startDispatching = '1' then
+            -- Event-driven launch: armed AND a complete packet is buffered. The
+            -- IDLE re-check re-fires immediately while more packets remain, so a
+            -- continuous PRBS stream produces continuous work requests.
+            if (r.dispatchEnable = '1') and (dispR.pktsAvail /= 0) then
                v.state := ST1_SENDING;
             end if;
 
          ---------------------------------------------------------------------
          when ST1_SENDING =>
             if v.txMaster.valid = '0' then
-               -- id = zero-pad & (count + 1).
-               v.txMaster.id     := idPadding & std_logic_vector(unsigned(dispR.count) + 1);
+               -- id = zero-pad & free-running work-request counter (wraps).
+               v.txMaster.id     := idPadding & dispR.idCnt;
                v.txMaster.opCode := x"1";
                v.txMaster.flags  := "00010";  -- RDMA Write with Immediate
                -- rAddr = rAddr + addrCount*len (product resized to 64 bits).
@@ -569,15 +577,12 @@ begin  -- architecture rtl
                   v.addrCount := std_logic_vector(nextAddr);
                end if;
 
-               -- Advance the dispatch counter; issue exactly DispatchCounter
-               -- work requests (one per accepted handshake) then return to idle.
-               if unsigned(dispR.count) < unsigned(r.dispatchCounter) - 1 then
-                  v.count := std_logic_vector(unsigned(v.count) + 1);
-                  v.state := ST1_SENDING;
-               else
-                  v.count := (others => '0');
-                  v.state := ST0_IDLE;
-               end if;
+               -- Advance the free-running work-request id and claim one buffered
+               -- packet. Return to IDLE, which re-fires next cycle if more packets
+               -- remain buffered and dispatch is still armed.
+               v.idCnt  := std_logic_vector(unsigned(dispR.idCnt) + 1);
+               pktClaim := '1';
+               v.state  := ST0_IDLE;
             end if;
 
          ---------------------------------------------------------------------
@@ -585,6 +590,17 @@ begin  -- architecture rtl
             v := DISP_INIT_C;
 
       end case;
+
+      -- Net update of the packet-available counter. Increment when a packet
+      -- enters the FIFO, decrement when one is claimed by an issued work request;
+      -- simultaneous enter+claim is a no-op (avoids a lost count). pktsAvail never
+      -- goes negative (a claim only happens while pktsAvail /= 0) and is bounded by
+      -- the FIFO packet capacity.
+      if (pktEnter = '1') and (pktClaim = '0') then
+         v.pktsAvail := dispR.pktsAvail + 1;
+      elsif (pktEnter = '0') and (pktClaim = '1') then
+         v.pktsAvail := dispR.pktsAvail - 1;
+      end if;
 
       -- Registered work-request master output.
       workReqMaster <= dispR.txMaster;

--- a/software/scripts/runPrbs.py
+++ b/software/scripts/runPrbs.py
@@ -162,11 +162,24 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--cases",
+        "--target",
         required = False,
-        default  = 1,
+        default  = 1000,
         type     = int,
-        help     = "Number of dispatch bursts (DispatchCounter) to send",
+        help     = "Number of PRBS frames to receive before declaring PASS "
+                   "(continuous event-driven dispatch)",
+    )
+
+    parser.add_argument(
+        "--trigRate",
+        required = False,
+        default  = 1e4,
+        type     = float,
+        help     = "PRBS packet rate in Hz (SsiPrbsTx.TrigRate). Default 1e4 keeps "
+                   "the host PrbsRx consumer from overrunning for clean continuous "
+                   "validation. Above ~tens of kHz the rogue zero-copy recv-slot "
+                   "re-post races the consumer and PRBS errors appear (host-stack "
+                   "limited, not a FW issue). Set 0 to free-run at full line rate",
     )
 
     parser.add_argument(
@@ -237,15 +250,9 @@ if __name__ == "__main__":
     pmtu_enum  = _PMTU_ENUM[args.pmtu]
     pmtu_bytes = args.pmtu
 
-    # Pre-flight --cases bounds: DispatchCounter is a 24-bit field; out-of-range
-    # counts can never pass the triple-assert, so reject them up front.
-    _CASES_MAX = (1 << 24) - 1
-    if not (1 <= args.cases <= _CASES_MAX):
-        print(
-            f"ERROR: --cases={args.cases} out of range — must be 1..{_CASES_MAX} "
-            f"(24-bit DispatchCounter).",
-            file=sys.stderr,
-        )
+    # --target is the number of frames to receive before PASS; must be positive.
+    if args.target < 1:
+        print(f"ERROR: --target={args.target} must be >= 1.", file=sys.stderr)
         sys.exit(1)
 
     # Resolve the RoCEv2 GID index: explicit --roceGidIndex overrides; otherwise
@@ -266,6 +273,43 @@ if __name__ == "__main__":
         print(f"Auto-detected --roceGidIndex {gidIndex} "
               f"(RoCE v2 IPv4 GID on {args.roceDevice})")
 
+    # ----------------------------------------------------------------
+    # Resolve the per-frame Len (bytes per RDMA WRITE) up front, BEFORE building
+    # the Root, because the host receive MR must be sized to match it.
+    #
+    # The host posts rxQueueDepth recv-WR slots, each exactly maxPayload bytes, at
+    # mrAddr + slot*maxPayload. The FW writes frame N to mrAddr + (N mod
+    # addrWrapCount)*Len. For every frame to land in its recv-WR slot — and for RC
+    # RNR flow control to throttle the FW to the host's consumption rate — the
+    # slot stride MUST equal the write stride: maxPayload == Len and
+    # addrWrapCount == rxQueueDepth. So we choose Len here and pass it as the host
+    # maxPayload (roceMaxPay) below.
+    #
+    # The PRBS word is 64-bit (8 B) <= the 32-byte RoCEv2 beat, so the granularity
+    # is the beat. A frame is an integer number of 32-byte beats, >= 2 beats, and
+    # strictly below PMTU (Len == PMTU stalls the single-packet dispatch).
+    # ----------------------------------------------------------------
+    ROCE_BEAT_BYTES = 32
+    gran = ROCE_BEAT_BYTES
+    if args.len is None:
+        Len = ((pmtu_bytes - 1) // gran) * gran
+    else:
+        Len = args.len
+        if Len >= pmtu_bytes:
+            print(
+                f"WARNING: --len={Len} >= PMTU={pmtu_bytes} — known-unsupported: "
+                f"Len == PMTU stalls dispatch and Len > PMTU hits the surf 13-bit "
+                f"DMA-read cap / per-message PrbsRx framing. Proceeding anyway.",
+                file=sys.stderr,
+            )
+    if Len % gran != 0 or Len < 2 * gran:
+        print(
+            f"ERROR: Len={Len} is invalid — must be a multiple of {gran} bytes "
+            f"and >= {2 * gran} bytes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     #################################################################
 
     with roceBoard.Root(
@@ -274,6 +318,7 @@ if __name__ == "__main__":
         roceDevice   = args.roceDevice,
         roceGidIndex = gidIndex,
         rocePmtu     = pmtu_enum,
+        roceMaxPay   = Len,                  # host slot stride == FW write stride
         pollEn       = args.pollEn,
         initRead     = args.initRead,
         zmqSrvPort   = args.zmqSrvPort,
@@ -308,11 +353,26 @@ if __name__ == "__main__":
         # host tracks the FW config instead of hard-coding the width.
         word_bytes = prbs.WordSize.get() // 8
 
-        # RoCEv2 payload beat width (TDATA_ROCE_NUM_BYTES_C). The engine packs the
-        # payload into 32-byte beats and rejects a partial final beat (isRespErr),
-        # so Len must be a whole number of BOTH PRBS words and 32-byte beats.
-        ROCE_BEAT_BYTES = 32
-        gran = max(ROCE_BEAT_BYTES, word_bytes)
+        # Len was chosen up front and passed as the host maxPayload; validate it
+        # against the FW's PRBS word size (PacketLength is counted in whole words).
+        if Len % word_bytes != 0:
+            print(
+                f"ERROR: Len={Len} is not a multiple of the {word_bytes}-byte PRBS "
+                f"word — adjust --len or --pmtu.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # The host MR slot stride (maxPayload) MUST equal the FW write stride (Len)
+        # so each RDMA WRITE lands exactly in its recv-WR slot (otherwise only the
+        # first frame validates). roceMaxPay=Len was set at construction; assert it.
+        if max_payload != Len:
+            print(
+                f"ERROR: host maxPayload={max_payload} != Len={Len}; FW write ring "
+                f"and host recv-WR ring are misaligned.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         # ----------------------------------------------------------------
         # Set UDP engine destination
@@ -323,36 +383,6 @@ if __name__ == "__main__":
         print(f"Setting UDP engine destination to {hostIp}:4791")
         root.Core.UdpEngine.ClientRemotePort[0].set(4791)
         root.Core.UdpEngine.ClientRemoteIp[0].set(hostIp)
-
-        # ----------------------------------------------------------------
-        # Resolve + validate the per-message Len (bytes per RDMA WRITE). A frame
-        # is an integer number of PRBS words (>= 2 words).
-        # ----------------------------------------------------------------
-        if args.len is None:
-            # Largest whole-granule Len STRICTLY below min(MaxPayload, PMTU).
-            # Strictly below PMTU because Len == PMTU stalls the single-packet
-            # dispatch (no work completion); floored to `gran` to avoid a partial
-            # final beat.
-            cap = min(max_payload, pmtu_bytes) - 1
-            Len = (cap // gran) * gran
-        else:
-            Len = args.len
-            if Len >= pmtu_bytes:
-                print(
-                    f"WARNING: --len={Len} >= PMTU={pmtu_bytes} — known-unsupported: "
-                    f"Len == PMTU stalls dispatch and Len > PMTU hits the surf 13-bit "
-                    f"DMA-read cap / per-message PrbsRx framing. Proceeding anyway.",
-                    file=sys.stderr,
-                )
-
-        if Len % gran != 0 or Len < 2 * gran:
-            print(
-                f"ERROR: Len={Len} is invalid — must be a multiple of {gran} bytes "
-                f"(max of the {ROCE_BEAT_BYTES}-byte RoCEv2 beat and the {word_bytes}-"
-                f"byte PRBS word) and >= {2 * gran} bytes.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
 
         print(
             f"--- RoCEv2 PRBS run parameters ---\n"
@@ -367,7 +397,7 @@ if __name__ == "__main__":
             f"  MrLen           : {mr_len}\n"
             f"  Len (per msg)   : {Len}\n"
             f"  PMTU            : {pmtu_bytes}\n"
-            f"  Cases           : {args.cases}\n"
+            f"  Target frames   : {args.target}\n"
             f"----------------------------------"
         )
 
@@ -388,6 +418,10 @@ if __name__ == "__main__":
 
             # Same register config as the PRBS path
             prbs.PacketLength.set(Len // word_bytes - 1)
+            if args.trigRate > 0:
+                prbs.TrigRate.set(args.trigRate)
+            else:
+                prbs.TrigDly.set(0)
             prbs.FwCnt.set(True)       # counter mode (runtime; 0x00[5])
             prbs.TxEn.set(True)        # enable the source (else it never free-runs)
 
@@ -397,25 +431,29 @@ if __name__ == "__main__":
             dma.SQpn.set(remQpn)
             dma.RemAddr.set(mrAddr)
             dma.AddrWrapCount.set(mr_len // Len)
-            dma.DispatchCounter.set(args.cases)
             # dma.DQpn left at default 0 — UD-datagram field, unused by the RC WRITE path.
 
             dma.ResetCounters()        # RemoteCommand toggle — zeroes FW counters
             root.CountReset()          # zeroes host PrbsRx counters
 
-            print(f"Counter-mode: dispatching {args.cases} burst(s) of {Len} bytes...")
-            dma.StartDispatching()
+            print(f"Counter-mode: capturing {args.target} frame(s) of {Len} bytes "
+                  f"(continuous dispatch)...")
+            dma.DispatchEnable.set(True)   # arm event-driven dispatch
 
-            # Poll to completion — fall through to assert on timeout, never raise
+            # Poll until enough frames captured — fall through to assert on timeout, never raise
             deadline = time.monotonic() + args.timeout
-            while dma.SuccessCounter.get() < args.cases and len(cap.frames) < args.cases:
+            while len(cap.frames) < args.target:
                 if time.monotonic() > deadline:
                     print(f"WARNING: timed out after {args.timeout}s waiting for "
-                          f"counter-mode completion (SuccessCounter="
+                          f"counter-mode capture (SuccessCounter="
                           f"{dma.SuccessCounter.get()}, frames={len(cap.frames)})",
                           file=sys.stderr)
                     break
                 time.sleep(0.05)
+
+            # Stop the stream before inspecting the captured frames.
+            dma.DispatchEnable.set(False)
+            prbs.TxEn.set(False)
 
             # ------------------------------------------------------------
             # Increment assertion — 32-bit counter ramp, one beat per PRBS word.
@@ -472,8 +510,8 @@ if __name__ == "__main__":
 
             print(
                 "--- counter-mode byte-order result ---\n"
-                f"  Frames captured        : {len(cap.frames)}\n"
-                f"  Dma.SuccessCounter     : {dma.SuccessCounter.get()} / {args.cases}\n"
+                f"  Frames captured        : {len(cap.frames)} (target {args.target})\n"
+                f"  Dma.SuccessCounter     : {dma.SuccessCounter.get()}\n"
                 f"  Beat layout            : {word_bytes}B/beat, beat0=seed beat1=len then +1 ramp\n"
                 "  Beat dump:\n" + "\n".join(dump_lines) + "\n"
                 f"  Failure                : {fail_reason if fail_reason else '(none)'}\n"
@@ -488,10 +526,13 @@ if __name__ == "__main__":
         # PacketLength is in PRBS words: (Len // word_bytes) - 1
         prbs.PacketLength.set(Len // word_bytes - 1)
 
-        # AXI_EN_G='1' means the host owns the trigger, so the SsiPrbsTx source
-        # never free-runs until TxEn is asserted. Without this the FIFO stays
-        # empty, REPACK stalls, and rxCount sticks at 0.
-        prbs.TxEn.set(True)
+        # PRBS packet rate. TrigDly=0 free-runs at full line rate; a positive
+        # --trigRate throttles the source so the host receive path keeps up
+        # (avoids overrun + PRBS continuity errors during a continuous run).
+        if args.trigRate > 0:
+            prbs.TrigRate.set(args.trigRate)
+        else:
+            prbs.TrigDly.set(0)
 
         dma.Len.set(Len)
         dma.RKey.set(mrRKey)
@@ -499,7 +540,6 @@ if __name__ == "__main__":
         dma.SQpn.set(remQpn)
         dma.RemAddr.set(mrAddr)
         dma.AddrWrapCount.set(mr_len // Len)
-        dma.DispatchCounter.set(args.cases)
         # dma.DQpn left at default 0 — UD-datagram field, unused by the RC WRITE path.
 
         # ----------------------------------------------------------------
@@ -509,35 +549,47 @@ if __name__ == "__main__":
         root.CountReset()          # zeroes host PrbsRx rxErrors/rxCount/rxBytes
 
         # ----------------------------------------------------------------
-        # Trigger the dispatch burst (rising-edge launch)
+        # Event-driven continuous run.
+        #
+        # DispatchEnable arms the FW dispatcher; TxEn free-runs the PRBS source
+        # (AXI_EN_G='1' means the host owns the trigger, so without TxEn the FIFO
+        # stays empty and nothing dispatches). With both set the FW issues one RDMA
+        # WRITE per complete buffered PRBS packet continuously — no per-frame poke.
         # ----------------------------------------------------------------
-        print(f"Dispatching {args.cases} burst(s) of {Len} bytes...")
-        dma.StartDispatching()
+        print(f"Streaming until rxCount >= {args.target} ({Len} bytes/frame)...")
+        dma.DispatchEnable.set(True)
+        prbs.TxEn.set(True)
 
         # ----------------------------------------------------------------
-        # Poll rxCount to completion
+        # Poll rxCount to the target — the receiver fills continuously
         # ----------------------------------------------------------------
         deadline = time.monotonic() + args.timeout
-        while root.PrbsRx.rxCount.get() < args.cases:
+        while root.PrbsRx.rxCount.get() < args.target:
             if time.monotonic() > deadline:
                 print(f"WARNING: timed out after {args.timeout}s waiting for "
-                      f"rxCount >= {args.cases}", file=sys.stderr)
+                      f"rxCount >= {args.target}", file=sys.stderr)
                 break                       # fall through to the assert; do NOT raise
             time.sleep(0.05)                # poll interval, NOT a completion sleep
 
         # ----------------------------------------------------------------
-        # Triple assert — cannot false-green on zero frames
+        # Stop the stream (disarm dispatch first, then quiesce the PRBS source)
+        # ----------------------------------------------------------------
+        dma.DispatchEnable.set(False)
+        prbs.TxEn.set(False)
+
+        # ----------------------------------------------------------------
+        # Assert — cannot false-green on zero frames
         # ----------------------------------------------------------------
         errs    = root.PrbsRx.rxErrors.get()
         rxCount = root.PrbsRx.rxCount.get()
         success = dma.SuccessCounter.get()
-        passed  = (errs == 0) and (rxCount > 0) and (success == args.cases)
+        passed  = (errs == 0) and (rxCount >= args.target)
 
         print(
             f"--- PRBS result ---\n"
             f"  PrbsRx.rxErrors        : {errs}\n"
-            f"  PrbsRx.rxCount         : {rxCount}\n"
-            f"  Dma.SuccessCounter     : {success} / {args.cases}\n"
+            f"  PrbsRx.rxCount         : {rxCount} (target {args.target})\n"
+            f"  Dma.SuccessCounter     : {success}\n"
             f"  RESULT                 : {'PASS' if passed else 'FAIL'}\n"
             f"-------------------"
         )
@@ -546,6 +598,11 @@ if __name__ == "__main__":
         # Development PyDM GUI
         ######################
         if (args.guiType == 'PyDM'):
+            # Re-arm the stream so the operator sees rxCount climbing live in the
+            # GUI. Toggle App.SsiPrbsTx.TxEn (or App.RoCEv2AxiStreamRdma.DispatchEnable)
+            # to start/stop continuous reception.
+            dma.DispatchEnable.set(True)
+            prbs.TxEn.set(True)
             pyrogue.pydm.runPyDM(
                 serverList = root.zmqServer.address,
                 sizeX      = 800,

--- a/software/setup_env_slac.sh
+++ b/software/setup_env_slac.sh
@@ -6,4 +6,4 @@ source /sdf/group/faders/users/$USER/miniforge3/etc/profile.d/conda.sh
 ##################################
 # Activate Rogue conda Environment
 ##################################
-conda activate rogue_v6.13.0
+conda activate rogue_v6.14.0


### PR DESCRIPTION
## Summary

Convert the RoCEv2 PRBS RDMA datapath from **pull-driven** to **event-driven** so the SW PRBS receiver streams continuously while `SsiPrbsTx.TxEn=True`, instead of only flowing when software toggled `StartDispatching`.

## Firmware (`RoCEv2AxiStreamRdma.vhd`)

- Replace the one-shot `StartDispatching` edge + `DispatchCounter` burst (and the `SynchronizerEdge`) with a level **`DispatchEnable`** register.
- Add a **`pktsAvail`** counter — incremented when a complete PRBS packet enters the repack FIFO (sAxis `tLast` handshake), decremented when a work request is issued. The DISPATCH FSM auto-issues exactly one RDMA WRITE-with-immediate per buffered packet while `DispatchEnable=1`, gating on a complete packet so REPACK never stalls mid-packet. Work-request id is free-running.

## Software

- `_RoCEv2AxiStreamRdma.py`: swap `StartDispatching` command for a `DispatchEnable` RW variable; drop `DispatchCounter`.
- `runPrbs.py`: continuous mode (`--target` frames, arm `DispatchEnable`+`TxEn`, poll `rxCount`, disarm) with deterministic pass/fail; GUI re-arms so `rxCount` climbs live.

## Pre-existing addressing fix

Making dispatch continuous exposed a mismatch masked by the old `--cases=1` default: the FW write ring (stride `Len`, wrap `mr_len/Len`) must equal the host recv-WR slot ring (stride `maxPayload`, `rxQueueDepth` slots), or **only frame 0 validates** (`rxCount=1`). Fixed host-side: `roceMaxPay=Len` makes `maxPayload==Len` and `addrWrapCount==rxQueueDepth`, so every frame lands in its slot. This also restores RC RNR flow control. Added `--trigRate` (default `1e4` Hz) since the host `PrbsRx` consumer is rate-limited above ~tens of kHz; `0` = full line rate.

## Hardware validation (`192.168.2.10`)

| Test | Result |
|------|--------|
| FW continuous dispatch | 2.6M work requests at line rate, no software poke |
| Default `runPrbs.py` | `rxErrors=0`, `rxCount=1013` — **PASS** |
| Counter-mode byte-order check | **PASS** |

## Notes

- The validation bitstream was a `dirty` build (built before this commit); logic is identical. Rebuild + reflash for a GitHash matching the merged commit if desired.
- Above ~tens of kHz the rogue zero-copy recv-slot re-post races the `PrbsRx` consumer (host-stack limited, not a FW issue) — hence the default `--trigRate`.